### PR TITLE
Allows users to change default GUID and UID for the JBoss EAP user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,13 +29,13 @@
     name: "{{ jboss_eap_group }}"
     system: yes
     state: present
-    gid: "400"
+    gid: "{{ jboss_eap_group_gid | default('400') }}"
 
 - name: Create JBoss EAP User
   user:
     name: "{{ jboss_eap_user }}"
     comment: "JBoss EAP User"
-    uid: "400"
+    uid: "{{ jboss_eap_user_uid | default('400') }}"
     group: "{{ jboss_eap_group }}"
     home: "{{ jboss_eap_library_dest_dir }}"
     shell: "/bin/bash"


### PR DESCRIPTION
@sabre1041 let's discuss here. As you can see if I nest the jcliff: module within the jboss_eap role, the use will need to provide the EAP/Wildfly subsystems configuration information, which is going to be complicated to specify as a data structures.

Rather than having jcliff: lives within the tasks/jboss_instances, I think it should be the only tasks defined into the playbook, which will mean something like that:

```
---
- name: "Ansible EAP Role demo"
  hosts: "{{ wildfly_ansible_hosts | default('localhost') }}"
  roles:
    - sabre1041.redhat-csp-download
    - redhat-cop.jcliff
    - redhat-cop.jboss_eap
  tasks:
    - name: "Define instance configuration"
      jcliff:
        wfly_home: "{{ jboss_eap_home }}"
        subsystems:
```

I have a feeling you would like to keep everything hidden within the jboss_eap role, but I don't know how to achieve that!

